### PR TITLE
Fix a few things with Home Assistant example

### DIFF
--- a/Software/examples/Home_Assistant_MQTT/sensor.yaml
+++ b/Software/examples/Home_Assistant_MQTT/sensor.yaml
@@ -1,47 +1,60 @@
-sensor:
-- platform: mqtt
-  name: "Volts 1"
-  state_topic: "home/energy/sensor"
-  value_template: '{{ value_json["V1"] }}'
-  unit_of_measurement: "Volts"
-- platform: mqtt
-  name: "Volts 2"
-  state_topic: "home/energy/sensor"
-  value_template: '{{ value_json["V2"] }}'
-  unit_of_measurement: "Volts"
-- platform: mqtt
-  name: "Amps 1"
-  state_topic: "home/energy/sensor"
-  value_template: '{{ value_json["I1"] }}'
-  unit_of_measurement: "Amps"
-- platform: mqtt
-  name: "Amps 2"
-  state_topic: "home/energy/sensor"
-  value_template: '{{ value_json["I2"] }}'
-  unit_of_measurement: "Amps"
-- platform: mqtt
-  name: "Amps Total"
-  state_topic: "home/energy/sensor"
-  value_template: '{{ value_json["totI"] }}'
-  unit_of_measurement: "Amps"
-- platform: mqtt
-  name: "Total Watts"
-  state_topic: "home/energy/sensor"
-  value_template: '{{ value_json["AP"] }}'
-  unit_of_measurement: "Watts"
-- platform: mqtt
-  name: "Power Factor"
-  state_topic: "home/energy/sensor"
-  value_template: '{{ value_json["PF"] }}'
-  unit_of_measurement: "Watts"
-- platform: mqtt
-  name: "Temperature"
-  state_topic: "home/energy/sensor"
-  value_template: '{{ value_json["t"] }}'
-  unit_of_measurement: "C"
-- platform: mqtt
-  name: "Frequency"
-  state_topic: "home/energy/sensor"
-  value_template: '{{ value_json["f"] }}'
-  unit_of_measurement: "Hz"
-  
+- sensor:
+  - platform: mqtt
+    name: "Volts 1"
+    state_topic: "home/energy/sensor"
+    value_template: '{{ value_json["V1"] | round(2) }}'
+    unit_of_measurement: "Volts"
+    device_class: "voltage"
+  - platform: mqtt
+    name: "Volts 2"
+    state_topic: "home/energy/sensor"
+    value_template: '{{ value_json["V2"] | round(2) }}'
+    unit_of_measurement: "Volts"
+    device_class: "voltage"
+  - platform: mqtt
+    name: "Amps 1"
+    state_topic: "home/energy/sensor"
+    value_template: '{{ value_json["I1"] | round(2) }}'
+    unit_of_measurement: "Amps"
+    device_class: "current"
+  - platform: mqtt
+    name: "Amps 2"
+    state_topic: "home/energy/sensor"
+    value_template: '{{ value_json["I2"] | round(2) }}'
+    unit_of_measurement: "Amps"
+    device_class: "current"
+  - platform: mqtt
+    name: "Amps Total"
+    state_topic: "home/energy/sensor"
+    value_template: '{{ value_json["totI"] | round(2) }}'
+    unit_of_measurement: "Amps"
+    device_class: "current"
+  - platform: mqtt
+    name: "Total Watts"
+    state_topic: "home/energy/sensor"
+    value_template: '{{ value_json["AP"] | round(1) }}'
+    unit_of_measurement: "Watts"
+    device_class: "power"
+  - platform: mqtt
+    name: "Power Factor"
+    state_topic: "home/energy/sensor"
+    value_template: '{{ (value_json["PF"] * 100.0) | round(1) }}'
+    unit_of_measurement: "%"
+    device_class: "power_factor"
+  - platform: mqtt
+    name: "Temperature"
+    state_topic: "home/energy/sensor"
+    value_template: '{{ value_json["t"] | round(1) }}'
+    unit_of_measurement: "C"
+    device_class: "temperature"
+  - platform: mqtt
+    name: "Frequency"
+    state_topic: "home/energy/sensor"
+    value_template: '{{ value_json["f"] | round(2) }}'
+    unit_of_measurement: "Hz"
+    device_class: "frequency"
+  - platform: integration
+    source: sensor.total_watts
+    name: energy_spent
+    unit_prefix: k
+    round: 2


### PR DESCRIPTION
Sorry about not splitting this up into multiple commits. I tinkered locally and once I got it all working I got it all moved back to upstream the fixes and changes. Included in this PR is:

 - Fix compile errors (global variable was not capitalized).
 - Add ability to disable WiFi/MQTT for calibration, useful if you want to calibrate before connecting to WiFi/MQTT.
 - Add auto-reboot on number of failures so sensor auto-reconnects after MQTT server downtime. I noticed when I applied updates and had to reboot my MQTT server I had to unplug/replug the kit. Auto-rebooting after a number of errors fixes this.
 - Update sensor.yaml example to play nicer with Home Assistant. Sorry about the block change, I think that was my git client updating line endings. If you diff with no whitespace you see that its updating to add device classes for all sensors which lets Home Assistant auto-pick the right icon and such, and rounded so that you don't get 10 digit decimals on your dashboards.
 - Adds a KWh intergation sensor to the sensor.yaml file. If you correctly categorized the total wattage input as "power" (which is done here) and then add an integration pointing to it (also done here), then it makes the "energy_spent" sensor available on the Energy dashboard. So I added that as an example to anyone else going the Home Assistant route so it works pretty much out of the box to get hourly/daily usage graphs.